### PR TITLE
Fixing headers overflowing into measurements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Read Observation file example
 -----------------------------
 ::
 
-    from pyrinex.readRinexObs import rinexobs
+    from pyrinex import rinexobs
 
     obsdata = rinexobs(rinexObsfilename)
 
@@ -48,7 +48,7 @@ Read Navigation file example
 ----------------------------
 ::
 
-    from pyrinex.readRinexNav import readRinexNav
+    from pyrinex import readRinexNav
     
     navdata = readRinexNav(rinexNavfilename)
 

--- a/pyrinex/__init__.py
+++ b/pyrinex/__init__.py
@@ -4,3 +4,5 @@ try:
 except (ImportError,AttributeError):
     from pathlib2 import Path
 
+from .readRinexObs import *
+from .readRinexNav import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ pytz
 numpy
 xarray
 pandas
-pytables
 h5py
-pytables
 matplotlib
 seaborn

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pandas.io.pytables import read_hdf
 from numpy.testing import assert_allclose,run_module_suite
 #
-from pyrinex.readRinexObs import rinexobs, readRinexNav
+from pyrinex import rinexobs, readRinexNav
 
 rdir=Path(__file__).parents[1]
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,8 +7,7 @@ from pathlib import Path
 from pandas.io.pytables import read_hdf
 from numpy.testing import assert_allclose,run_module_suite
 #
-from pyrinex.readRinexObs import rinexobs
-from pyrinex.readRinexNav import readRinexNav
+from pyrinex.readRinexObs import rinexobs, readRinexNav
 
 rdir=Path(__file__).parents[1]
 


### PR DESCRIPTION
In case there were more than 12 satellites the header lines would start overflowing into measurements. Consider the following data:

 15 07 01 00 00  0.0000000  0 19G01G03G06G09G10G17G23G25G31G32R04R05
                                R06R13R14R15R19R20R22
  24081967.254   126551622.821       -3808.254          47.750    24081967.926
  98611686.936       -2967.473          38.000
  20771346.215   109154158.216       -1652.762          51.750    20771345.073
  85055188.129       -1287.871          49.750
...

block = ''.join(lines[headlines[i]+1:headlines[i]+linesinblock+1])
would start at the row containing "R06R13R14R15R19R20R22" which would corrupt the data by inserting a random string as well as shifting all other measurements by one row.
